### PR TITLE
Handle an edge case where `CUDA_HOME` is not defined on ROCm systems

### DIFF
--- a/op_builder/gds.py
+++ b/op_builder/gds.py
@@ -49,6 +49,11 @@ class GDSBuilder(AsyncIOBuilder):
             return False
 
         CUDA_HOME = torch.utils.cpp_extension.CUDA_HOME
+        if CUDA_HOME is None:
+            if verbose:
+                self.warning("Please install torch CUDA if trying to pre-compile GDS with CUDA")
+            return False
+
         CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
         gds_compatible = self.has_function(funcname="cuFileDriverOpen",
                                            libraries=("cufile", ),


### PR DESCRIPTION
* Handles an edge case when building `gds` where `CUDA_HOME` is not defined on ROCm systems